### PR TITLE
Rename Hazelcast caches to fix Datasets/MIA Hazelcast serialization exceptions during parallel work (Rel. issue https://github.com/Netcracker/qubership-testing-platform-datasets/issues/4)

### DIFF
--- a/atp-dataset-benchmarks/pom.xml
+++ b/atp-dataset-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-dependencies</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent/parent-dependencies/pom.xml</relativePath>
     </parent>
 

--- a/atp-dataset-common/pom.xml
+++ b/atp-dataset-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-java</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/atp-dataset-distribution/pom.xml
+++ b/atp-dataset-distribution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-dependencies</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent/parent-dependencies/pom.xml</relativePath>
     </parent>
 

--- a/atp-dataset-import/pom.xml
+++ b/atp-dataset-import/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-db</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent/parent-db/pom.xml</relativePath>
     </parent>
 

--- a/atp-dataset-migration/pom.xml
+++ b/atp-dataset-migration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-db-properties</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent/parent-db-properties/pom.xml</relativePath>
     </parent>
 

--- a/atp-dataset-openapi-specifications/pom.xml
+++ b/atp-dataset-openapi-specifications/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-dependencies</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent/parent-dependencies/pom.xml</relativePath>
     </parent>
 
     <artifactId>atp-dataset-openapi-specifications</artifactId>
     <name>atp-dataset-openapi-specifications</name>
-    <version>1.3.160-SNAPSHOT</version>
+    <version>1.3.161-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <build>

--- a/atp-dataset-q-classes-generation/pom.xml
+++ b/atp-dataset-q-classes-generation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-db-properties</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent/parent-db-properties/pom.xml</relativePath>
     </parent>
 

--- a/atp-dataset/pom.xml
+++ b/atp-dataset/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-db</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent/parent-db/pom.xml</relativePath>
     </parent>
 

--- a/atp-dataset/src/main/config/application.properties
+++ b/atp-dataset/src/main/config/application.properties
@@ -42,7 +42,7 @@ spring.sleuth.web.additional-skip-pattern=/health/visibility_areas_list
 ##==================atp-auth-spring-boot-starter=====================
 # spring
 spring.profiles.active=${SPRING_PROFILES:disable-security}
-spring.cache.cache-names=projects
+spring.cache.cache-names=auth_projects
 spring.cache.caffeine.spec=maximumSize=100, expireAfterAccess=120s, expireAfterWrite=120s
 # keycloak
 keycloak.enabled=${KEYCLOAK_ENABLED:false}

--- a/atp-dataset/src/main/java/org/qubership/atp/dataset/constants/CacheEnum.java
+++ b/atp-dataset/src/main/java/org/qubership/atp/dataset/constants/CacheEnum.java
@@ -36,7 +36,7 @@ public enum CacheEnum {
     }
 
 public static class Constants {
-    public static final String PROJECT_CACHE = "projects";
+    public static final String PROJECT_CACHE = "ATP_DATASETS_PROJECTS";
     public static final String DATASET_LIST_CONTEXT_CACHE = "ATP_DATASETS_DATASET_LIST_CONTEXT_CACHE";
 
     public static final String JAVERS_DIFF_CACHE = "JAVERS_DIFF_CACHE";

--- a/atp-dataset/src/main/java/org/qubership/atp/dataset/constants/CacheEnum.java
+++ b/atp-dataset/src/main/java/org/qubership/atp/dataset/constants/CacheEnum.java
@@ -36,10 +36,10 @@ public enum CacheEnum {
     }
 
 public static class Constants {
-    public static final String PROJECT_CACHE = "ATP_DATASETS_PROJECTS";
-    public static final String DATASET_LIST_CONTEXT_CACHE = "ATP_DATASETS_DATASET_LIST_CONTEXT_CACHE";
+    public static final String PROJECT_CACHE = "ATP_DATASETS_PROJECTS_OS";
+    public static final String DATASET_LIST_CONTEXT_CACHE = "ATP_DATASETS_DATASET_LIST_CONTEXT_CACHE_OS";
 
-    public static final String JAVERS_DIFF_CACHE = "JAVERS_DIFF_CACHE";
-    public static final String PARAMETER_CACHE = "ATP_DATASETS_PARAMETER_CACHE";
+    public static final String JAVERS_DIFF_CACHE = "JAVERS_DIFF_CACHE_OS";
+    public static final String PARAMETER_CACHE = "ATP_DATASETS_PARAMETER_CACHE_OS";
 }
 }

--- a/atp-dataset/src/main/java/org/qubership/atp/dataset/kafka/handlers/project/strategies/DeleteProjectProcessingStrategy.java
+++ b/atp-dataset/src/main/java/org/qubership/atp/dataset/kafka/handlers/project/strategies/DeleteProjectProcessingStrategy.java
@@ -16,6 +16,7 @@
 
 package org.qubership.atp.dataset.kafka.handlers.project.strategies;
 
+import org.qubership.atp.dataset.constants.CacheEnum;
 import org.qubership.atp.dataset.kafka.entities.project.EventType;
 import org.qubership.atp.dataset.kafka.entities.project.ProjectEvent;
 import org.qubership.atp.dataset.kafka.handlers.project.ProcessingStrategy;
@@ -31,13 +32,12 @@ import org.springframework.stereotype.Component;
         matchIfMissing = false
 )
 public class DeleteProjectProcessingStrategy implements ProcessingStrategy<ProjectEvent, EventType> {
-    public static final String PROJECTS_CACHE_NAME = "projects";
 
     @Autowired
     private VisibilityAreaService visibilityAreaService;
 
     @Override
-    @CacheEvict(value = PROJECTS_CACHE_NAME, key = "#projectEvent.getProjectId()")
+    @CacheEvict(value = CacheEnum.Constants.PROJECT_CACHE, key = "#projectEvent.getProjectId()")
     public void process(ProjectEvent projectEvent) {
         visibilityAreaService.delete(projectEvent.getProjectId());
     }

--- a/parent/parent-db-properties/pom.xml
+++ b/parent/parent-db-properties/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-java</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent-java/pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/parent/parent-db/pom.xml
+++ b/parent/parent-db/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-db-properties</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent-db-properties/pom.xml</relativePath>
     </parent>
 

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -18,12 +18,12 @@
         <spring.cloud.version>2021.0.8</spring.cloud.version>
         <javers.spring.boot.starter.sql.version>6.8.2</javers.spring.boot.starter.sql.version>
 
-        <atp.auth.version>1.2.60</atp.auth.version>
+        <atp.auth.version>1.2.62-SNAPSHOT</atp.auth.version> <!-- build from rename-projects-cache branch -->
         <atp.common.version>0.0.43</atp.common.version>
         <atp-crypt.version>0.0.20</atp-crypt.version>
         <atp.integration.version>0.2.38</atp.integration.version>
-        <ei.version>0.2.40</ei.version>
-        <macros.core.version>1.0.27</macros.core.version>
+        <ei.version>0.2.42-SNAPSHOT</ei.version> <!-- snapshot build with rename-projects-cache branch of auth -->
+        <macros.core.version>1.0.30-SNAPSHOT</macros.core.version> <!-- snapshot build with rename-projects-cache branch of auth -->
         <atp.saga.coordinator.version>0.0.9</atp.saga.coordinator.version>
 
         <querydsl.version>5.0.0</querydsl.version>

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-aggregator</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -18,12 +18,12 @@
         <spring.cloud.version>2021.0.8</spring.cloud.version>
         <javers.spring.boot.starter.sql.version>6.8.2</javers.spring.boot.starter.sql.version>
 
-        <atp.auth.version>1.2.62-SNAPSHOT</atp.auth.version> <!-- build from rename-projects-cache branch -->
+        <atp.auth.version>1.2.68</atp.auth.version>
         <atp.common.version>0.0.43</atp.common.version>
         <atp-crypt.version>0.0.20</atp-crypt.version>
         <atp.integration.version>0.2.38</atp.integration.version>
-        <ei.version>0.2.42-SNAPSHOT</ei.version> <!-- snapshot build with rename-projects-cache branch of auth -->
-        <macros.core.version>1.0.30-SNAPSHOT</macros.core.version> <!-- snapshot build with rename-projects-cache branch of auth -->
+        <ei.version>0.2.43</ei.version>
+        <macros.core.version>1.0.31</macros.core.version>
         <atp.saga.coordinator.version>0.0.9</atp.saga.coordinator.version>
 
         <querydsl.version>5.0.0</querydsl.version>

--- a/parent/parent-java/pom.xml
+++ b/parent/parent-java/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.dataset</groupId>
         <artifactId>atp-dataset-parent-dependencies</artifactId>
-        <version>1.3.160-SNAPSHOT</version>
+        <version>1.3.161-SNAPSHOT</version>
         <relativePath>../parent-dependencies/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.qubership.atp.dataset</groupId>
     <artifactId>atp-dataset-aggregator</artifactId>
-    <version>1.3.160-SNAPSHOT</version>
+    <version>1.3.161-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Fix exceptions thrown in Datasets and/or MIA (https://github.com/Netcracker/qubership-testing-platform-datasets/issues/4) when opensource Datasets service and internal MIA service work together.
<!-- start messages -->
### Commit messages:
[kagw95](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/3e91db29bbca7876ff1449a35fc0a5782757dc3f) Hazelcast Projects cache is renamed.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/dfd3b29c9a850189552817c96b9b880fef657df4) Projects cache is renamed. auth-lib dependency version is changed.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/b79202cacc43e4ec5488360fded0a6287f34eea6) Dependencies versions are changed: atp-auth to 1.2.68, export-import to 0.2.43, macros-core to 1.0.31. Caches names are changed. Version is changed to 1.3.161-SNAPSHOT.
<!-- end messages -->
