### PR TITLE
fix: Enhance security scan workflow and GHCR package handling

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -83,7 +83,7 @@ jobs:
     uses: netcracker/qubership-workflow-hub/.github/workflows/re-security-scan.yml@main
     with:
       target: ${{ inputs.target || 'docker' }}
-      image: ${{ format('{0}:latest', matrix.package.path) }}
+      image: ${{ format('{0}:{1}', matrix.package.path, inputs.tag) }}
 
   security-scan-single:
     needs: debug-packages


### PR DESCRIPTION
Improve the security scan job by refining the repository selection logic, correcting jq command syntax, and enhancing package fetching with pagination and error handling. Update the workflow to streamline processes, set strict error handling, and adjust image tag formats. Additionally, implement a scheduled check every 5 minutes for improved monitoring.
<!-- start messages -->
### Commit messages:
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/82bae8ea06aa95b9c5ea3d437ab92a3e7664cc6f) fix(security-scan): remove debug output for GHCR response in security scan job
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/b3966b93a189a204df7628a96984d69cc427fb9f) fix(security-scan): update repository selection logic in security scan job
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/deb99552f7682f7cf9e269b89b2672575353aa12) fix(security-scan): correct jq command to include repository variable in package selection
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/97b4803315e05e3eb948a39388493c6e6d6dd499) fix(security-scan): comment out security scan jobs for matrix and single image
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/4295ce8fc1def3c67a74d3e1e805b9b0e8d90730) fix(security-scan): comment out debug output for raw GHCR response in security scan job
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/95ecf4bb3f8cc5ec17c127d76352ebf56d921566) fix(security-scan): correct jq command syntax for package selection in security scan job
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/e4db5cff5fbd448ff8ce910767479298238ca55c) fix(security-scan): correct jq command syntax for parsing packages in security scan job
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/cd6eb3728cd027944430eb9e1cff7ad4254b3818) fix(security-scan): correct jq command syntax for displaying parsed packages in security scan job
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/f0851753f572e2c55f4be00b35fc3b291504a3bc) fix(security-scan): update API URL for package retrieval and comment out debug output in security scan job
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/bb8d589605113864b3a9f0a40ad32707089b5da9) fix(security-scan): output parsed packages to GitHub Actions output and display them using jq
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/4f3246959ae04cd52bc61d99855d778bcacfb805) fix(security-scan): add log for fetching GHCR packages with owner and repo details
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/8ad26297cda699f394f049da1485bfee27f0e28a) fix(security-scan): correct variable usage in jq command for package filtering
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/4c18b0fdc4cc4d8eb71625b2ca07cfd505594b7f) fix(security-scan): add echo command to output repository full names from GHCR response
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/25a04b71e933830495949bc453107914e92ded54) fix(security-scan): update API URL to fetch GHCR packages for organization instead of user
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/f2a45445f0956f0a4ef34ec0279047d97747ff25) fix(security-scan): correct string interpolation in jq command for package filtering
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/4f0171fe20cb6d3656c5d0b06075a8f96005e0b7) fix(security-scan): update debug output for raw GHCR response and comment out package parsing
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/0554759efe6e96ed25d21e80087b953aafd945f4) fix(security-scan): save and upload raw GHCR response as JSON artifact
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/1500f81320de9d6a94b2b523be39d3531409ec97) fix(security-scan): update API URL to include pagination for GHCR packages
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/b554c56d14b08ff8737d5a7fa5fe097978d7c7db) fix(security-scan): correct API URL query parameter syntax for fetching GHCR packages
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/f87cb7d6ed20d2438eb53292a7b1d0bf3903c41f) fix(security-scan): enhance GHCR package fetching with pagination and error handling
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/7c5b36d9ffb5df756c8729a612f3bb34135a814e) fix(security-scan): enhance GHCR package fetching to store all packages and filtered results
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/38f0010c1a174fac2e2ff3bcb1a1f4d10f6c694c) fix(security-scan): update security scan workflow to set strict error handling and pagination
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/0b49f7026ef6186345bc54dc32e626e9ad537409) fix(security-scan): comment out output of filtered GHCR packages in security scan workflow
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/b4f7c02091e3dcad187329091698ed3b7986ef10) fix(security-scan): streamline GHCR package fetching process in security scan workflow
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/77fa38250df8631c83d451a2d83dada1aeb37c0b) fix(security-scan): restore security scan matrix and single image jobs in workflow
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/8935d05af8b89591f1eaa45f535da4714063d5f0) fix(security-scan): update repository selection criteria in GHCR package filtering
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/e91ab2ff88c310858a281c5e0b76af158746fdc3) fix(security-scan): comment out security scan matrix and single image jobs in workflow
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/c0b3a7bb9fc723e6bdb714a9f34244aadfab7400) fix(security-scan): restore security scan matrix and single image jobs in workflow
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/d98b4b75101226fc95e8a53944c0dadf97156710) fix(security-scan): update image tag format from 'main' to 'latest' in security scan workflow
[nookyo](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/d4fc2254d0d29b3b3055e6741dc7eacb199f2e47) feat: every 5 min check
<!-- end messages -->
