### PR TITLE
fix: NullPointerException due to null parameter value for DSL reference parameters is fixed

### DIFF
--- a/atp-dataset/src/main/java/org/qubership/atp/dataset/service/direct/importexport/converters/DatasetLinkAttributeExportConverter.java
+++ b/atp-dataset/src/main/java/org/qubership/atp/dataset/service/direct/importexport/converters/DatasetLinkAttributeExportConverter.java
@@ -51,6 +51,7 @@ public class DatasetLinkAttributeExportConverter implements AttributeExportConve
             Cell cell = row.createCell(nextCellIndex++);
             UiManParameter parameter = mapParameterWithDataSet.get(datasetId);
             if (Objects.nonNull(reference) && Objects.nonNull(parameter)
+                    && Objects.nonNull(parameter.getValue())
                     && Strings.isNotBlank(parameter.getValue().toString())) {
                 cell.setCellValue(String.format("%s %s %s",
                         reference.getName(), REFERENCE_DELIMITER, parameter.getValue()));


### PR DESCRIPTION
Export failed due to NullPointerException in case DSL reference parameter value was null.
A checking is added to avoid NPE in that case.
<!-- start messages -->
### Commit messages:
[akshaymahajan855](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/3769eb449330e419dd5778edbfd2e9938e4b251d) fix: fix NPE for paramater value.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-datasets/commit/4143047d64913ad330fa28efc31801dfbe10312e) Merge pull request #54 from akshaymahajan855/fix_npe_issue

fix: fix NPE for parameter value
<!-- end messages -->
